### PR TITLE
Profesionalizar configuración, CI/CD y seguridad

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Informe de error
+about: Comunica un comportamiento incorrecto o inesperado
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## Descripción
+
+Describe de forma clara qué ocurre y cuál era el comportamiento esperado.
+
+## Pasos para reproducirlo
+
+1. <!-- Primer paso -->
+2. <!-- Segundo paso -->
+3. <!-- Tercer paso -->
+
+## Comportamiento esperado
+
+Explica qué debería haber ocurrido.
+
+## Evidencias
+
+Añade capturas, registros o enlaces relevantes, sin incluir información sensible.
+
+## Entorno
+
+- Navegador y versión:
+- Sistema operativo:
+- Dispositivo o tamaño de pantalla:
+- URL o commit afectado:
+
+## Información adicional
+
+Incluye cualquier otro dato que ayude a diagnosticar el problema.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Solicitud de mejora
+about: Propón una funcionalidad o mejora para el proyecto
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+---
+
+## Problema o necesidad
+
+Describe qué problema resolvería esta propuesta y a quién beneficia.
+
+## Solución propuesta
+
+Explica el comportamiento deseado de forma concreta.
+
+## Alternativas consideradas
+
+Indica otras opciones valoradas y por qué no resultan suficientes.
+
+## Alcance
+
+Detalla qué partes del proyecto se verían afectadas y qué queda fuera de la propuesta.
+
+## Información adicional
+
+Añade referencias, bocetos o ejemplos que ayuden a evaluar la solicitud.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+      time: '06:00'
+      timezone: Europe/Madrid
+    target-branch: master
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+      time: '06:30'
+      timezone: Europe/Madrid
+    target-branch: master
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Resumen
+
+Describe brevemente el objetivo y el resultado de este pull request.
+
+## Tipo de cambio
+
+- [ ] Corrección de error
+- [ ] Nueva funcionalidad
+- [ ] Refactorización
+- [ ] Documentación
+- [ ] CI/CD o mantenimiento
+
+## Cambios realizados
+
+- <!-- Describe un cambio relevante -->
+
+## Validación
+
+Indica los comandos ejecutados y cualquier comprobación manual relevante.
+
+- [ ] `npm ci`
+- [ ] `npm run build`
+- [ ] He comprobado el comportamiento afectado
+
+## Checklist
+
+- [ ] El cambio está limitado al alcance del pull request
+- [ ] No he incluido credenciales, secretos ni archivos generados
+- [ ] He mantenido el estilo y las convenciones del proyecto
+- [ ] He actualizado la documentación si era necesario
+- [ ] CI y CodeQL finalizan correctamente

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,26 +2,55 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches-ignore:
+      - gh-pages
   pull_request:
-    branches: [master]
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Build project
-        run: npm run build -- --base-href /yariel-portfolio/
+      - name: Build application
+        run: npm run deploy:local
+
+      - name: Upload deployment artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-pages
+          path: dist/yariel-portfolio/browser
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy:
+    name: Deploy
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: build
+    permissions:
+      contents: write
+    uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,30 +2,40 @@ name: CodeQL
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
   pull_request:
-    branches: [master]
+    branches:
+      - master
   schedule:
     - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
-    name: Analyze TypeScript
+    name: Analyze JavaScript and TypeScript
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       security-events: write
       packages: read
-      actions: read
       contents: read
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,34 +1,35 @@
-name: Deploy Portfolio
+name: Deploy GitHub Pages
 
 on:
-  push:
-    branches: [master]
+  workflow_call:
 
 permissions:
   contents: write
 
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
 jobs:
   deploy:
+    name: Publish gh-pages
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: https://yrobainah.github.io/yariel-portfolio/
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Download deployment artifact
+        uses: actions/download-artifact@v4
         with:
-          node-version: 22
-          cache: npm
+          name: github-pages
+          path: dist
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build Angular app
-        run: npm run build -- --base-href /yariel-portfolio/
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Publish to gh-pages
+        uses: peaceiris/actions-gh-pages@1ef5a1b1df4c63fe21a2242edbee6cac921ece01 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist/yariel-portfolio/browser
+          publish_dir: ./dist
+          publish_branch: gh-pages
+          force_orphan: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contribuir al proyecto
+
+Gracias por tu interés en mejorar este portfolio. Este repositorio mantiene cambios pequeños, revisables y centrados en un único objetivo.
+
+## Requisitos
+
+- Node.js 22
+- npm incluido con Node.js
+- Git
+
+## Preparar el entorno
+
+1. Crea un fork o una rama a partir de `master`.
+2. Instala las dependencias de forma reproducible:
+
+   ```bash
+   npm ci
+   ```
+
+3. Inicia el entorno local:
+
+   ```bash
+   npm start
+   ```
+
+## Validaciones
+
+Antes de abrir un pull request, ejecuta:
+
+```bash
+npm run build
+```
+
+Para reproducir en local el build usado por GitHub Pages:
+
+```bash
+npm run deploy:local
+```
+
+## Convenciones
+
+- Mantén cada cambio dentro del alcance descrito en el pull request.
+- No incluyas credenciales, tokens, archivos generados ni dependencias instaladas.
+- Respeta el estilo y la estructura existentes.
+- Usa commits siguiendo [Conventional Commits](https://www.conventionalcommits.org/), por ejemplo:
+  - `feat: add a new capability`
+  - `fix: correct navigation behavior`
+  - `docs: update contribution guide`
+  - `ci: improve build workflow`
+- Actualiza la documentación cuando cambie el proceso de desarrollo.
+
+## Pull requests
+
+- Dirige el pull request a `master`.
+- Completa la plantilla y explica qué cambia y cómo se validó.
+- Comprueba que CI y CodeQL finalizan correctamente.
+- Mantén el pull request enfocado; separa cambios no relacionados.
+- Solicita revisión antes de hacer merge.
+
+Al contribuir aceptas que tu aportación se distribuya bajo los mismos términos que el resto del repositorio.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Política de seguridad
+
+## Versiones compatibles
+
+La rama `master` es la única versión mantenida y recibe las correcciones de seguridad. Las ramas de desarrollo y despliegue no se consideran versiones compatibles.
+
+## Comunicar una vulnerabilidad
+
+No publiques vulnerabilidades en un issue, discusión o pull request público.
+
+1. Utiliza **Security > Report a vulnerability** en GitHub para enviar un informe privado, si la opción está disponible.
+2. Si el canal privado no está habilitado, contacta primero con el propietario del repositorio a través de GitHub sin incluir detalles explotables públicamente.
+3. Incluye una descripción clara, pasos de reproducción, impacto estimado y una posible mitigación si la conoces.
+
+Se intentará confirmar la recepción en un plazo de 7 días y comunicar el progreso mientras se analiza el informe. Los plazos de corrección dependerán de la severidad y complejidad del problema.
+
+## Alcance
+
+Se consideran dentro del alcance:
+
+- El código fuente de la aplicación.
+- La configuración de compilación y despliegue.
+- Los workflows de GitHub Actions.
+- Dependencias con impacto demostrable en la aplicación desplegada.
+
+Los problemas sin impacto de seguridad verificable deben comunicarse mediante la plantilla de errores del repositorio.
+
+Gracias por ayudar a mantener el proyecto y a sus usuarios seguros.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "ci": "npm ci && npm run build",
+    "deploy:local": "npm run build -- --base-href /yariel-portfolio/",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },


### PR DESCRIPTION
## Resumen

- Consolida el build y el despliegue sin duplicar la compilación.
- Mantiene GitHub Pages publicado desde gh-pages.
- Actualiza CI y CodeQL, con Node.js 22, caché npm, permisos mínimos y concurrencia.
- Añade guías de contribución y seguridad.
- Añade plantillas de repositorio y Dependabot.

## Validación

- npm ci
- npm run build
- npm run deploy:local

## Notas de despliegue

El despliegue continúa usando la rama gh-pages para evitar cambios manuales en la fuente de publicación de GitHub Pages.