### PR TITLE
fix(projects): corrects projects images path

### DIFF
--- a/src/app/sections/projects/projects.ts
+++ b/src/app/sections/projects/projects.ts
@@ -16,21 +16,21 @@ export class Projects {
       title: 'SmartInventory',
       description:
         'Sistema profesional de gestión de inventario desarrollado con Spring Boot y Angular. Incluye autenticación JWT, dashboard analítico, control de stock, arquitectura multicapa y despliegue con Docker.',
-      image: '/assets/dashboard-desktop.png',
+      image: 'assets/dashboard-desktop.png',
       url: 'https://github.com/Yrobainah/SmartInventory',
     },
     {
       title: 'Portfolio Angular',
       description:
         'Aplicación de portafolio personal desarrollada con Angular y Tailwind CSS.',
-      image: '/assets/Home_Page_Portfolio.png',
+      image: 'assets/Home_Page_Portfolio.png',
       url: 'https://github.com/Yrobainah/yariel-portfolio',
     },
     {
       title: 'TradeSphere',
       description:
         'Aplicación fullstack con Java + Spring Boot y Angular para gestión de productos.',
-      image: '/assets/projects/tradesphere.png',
+      image: 'assets/projects/tradesphere.png',
       url: 'https://github.com/Yariel/tradesphere',
     },
   ];


### PR DESCRIPTION
## Resumen

Este pull request corrige las rutas de las imágenes de los proyectos **SmartInventory y Portfolio** para garantizar su correcta visualización en el portfolio desplegado mediante GitHub Pages.

### Problema

Las imágenes de los proyectos se mostraban correctamente en el entorno local, pero no en la versión publicada debido a una ruta de recursos incompatible con el despliegue bajo la subruta `yariel-portfolio`.

### Cambios

* Se corrigió las rutas de las imágenes de los proyectos **SmartInventory y Portfolio**.
* Se verificó la compatibilidad con GitHub Pages.
* No se realizaron cambios en el diseño ni en la funcionalidad del carrusel.

### Validación

* [x] Las imágenes se visualizan correctamente en el entorno local.
* [x] El proyecto compila correctamente.
* [ ] Verificar la visualización en GitHub Pages tras el despliegue automático.

### Resultado esperado

Después de fusionar este pull request, las imágenes de los proyectos **SmartInventory y Portfolio** deberán mostrarse correctamente tanto en desarrollo como en la versión publicada del portfolio.
